### PR TITLE
Use hash instead of query to share list

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Build and Deploy TopList
 on:
   push:
     branches:
-      - master
+      - '**'
 
 jobs:
   build:

--- a/straw/closed/use_github_actions_to_perform_build_and_pages_publish.md
+++ b/straw/closed/use_github_actions_to_perform_build_and_pages_publish.md
@@ -1,0 +1,1 @@
+# Use github actions to perform build and pages publish

--- a/straw/closed/use_hash_instead_of_query_to_share_list.md
+++ b/straw/closed/use_hash_instead_of_query_to_share_list.md
@@ -3,4 +3,9 @@
 The hash part of the url is not sent to servers. This is a great feature to
 keep shared data safer.
 
+## Notes
+
+- Keep backwards compatibility by supporting the append search param. Do this
+  for atleast the duration that these urls are being used.
+
   #priority

--- a/util.mjs
+++ b/util.mjs
@@ -34,3 +34,11 @@ export const moveItemToTop = (arr, n) => {
 
   return arr;
 };
+
+export const tryCatch = (doFn, catchFn) => {
+  try {
+    return doFn();
+  } catch (error) {
+    return catchFn(error);
+  }
+};


### PR DESCRIPTION
The hash part of the url is not sent to servers. This is a great feature to keep shared data safer.