### PR TITLE
Remove heading from lists

### DIFF
--- a/straw/open/remove_heading_from_lists.md
+++ b/straw/open/remove_heading_from_lists.md
@@ -1,0 +1,4 @@
+# Remove heading from lists
+
+The headings make little sense. Just show the lists and the list actions
+dropdown.

--- a/toplist.mjs
+++ b/toplist.mjs
@@ -114,11 +114,6 @@ const newList = () => ({
 
 data.lists[0] = data.lists[0] ?? newList();
 
-const toLocaleString = (value) => {
-  if (typeof value === "string") return toLocaleString(new Date(value));
-  return value.toLocaleString();
-};
-
 const mergeItems = (items) => () => {
   window.dialog.close();
   data.lists[0].items.push(...items);


### PR DESCRIPTION
The headings make little sense. Just show the lists and the list actions dropdown.